### PR TITLE
use relative submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib_seeds_revised"]
 	path = lib_seeds_revised
-	url = https://github.com/davidstutz/seeds-revised
+	url = ../seeds-revised
 [submodule "lib_vlfeat"]
 	path = lib_vlfeat
-	url = https://github.com/davidstutz/vlfeat
+	url = ../vlfeat


### PR DESCRIPTION
use relative submodules so that users can get submodules over their preferred transport (ssh://, git://, https://, …). This removes the "enter github password" error when trying to clone the main project.