### PR TITLE
fix vlfeat_slic_cli linking (pthread error)

### DIFF
--- a/vlfeat_slic_cli/CMakeLists.txt
+++ b/vlfeat_slic_cli/CMakeLists.txt
@@ -1,5 +1,8 @@
 include_directories(../lib_seeds_revised/ ../lib_vlfeat/vl/)
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+find_package(Threads REQUIRED)
+
 find_package(Boost COMPONENTS system filesystem program_options REQUIRED)
 find_package(OpenCV REQUIRED)
 
@@ -44,4 +47,4 @@ add_library(vlfeat
     ../lib_vlfeat/vl/vlad.c)
 
 add_executable(vlfeat_slic_cli main.cpp)
-target_link_libraries(vlfeat_slic_cli ${Boost_LIBRARIES} ${OpenCV_LIBS} vlfeat seeds_revised)
+target_link_libraries(vlfeat_slic_cli ${Boost_LIBRARIES} ${OpenCV_LIBS} vlfeat seeds_revised ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Fixes the following error during compilation (linking):

/usr/bin/ld: ../../lib/libvlfeat.a(generic.c.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: **\* [../bin/vlfeat_slic_cli] Error 1
make[1]: **\* [vlfeat_slic_cli/CMakeFiles/vlfeat_slic_cli.dir/all] Error 2
make: **\* [all] Error 2

For more details, see:
http://stackoverflow.com/questions/25617839/undefined-reference-to-symbol-pthread-key-deleteglibc-2-2-5
